### PR TITLE
Add aiohttp requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.101.1
 uvicorn==0.23.2
 requests==2.31.0
+aiohttp==3.8.5


### PR DESCRIPTION
```
python main.py --type vllm --model TheBloke/MythoMax-L2-13B-AWQ -q awq
Traceback (most recent call last):
  File "/projects/tgi-kai-bridge/main.py", line 14, in <module>
    from drivers import InferenceEngine, DummyInferenceEngine, VLLMInferenceEngine, \
  File "/projects/tgi-kai-bridge/drivers.py", line 5, in <module>
    import aiohttp
ModuleNotFoundError: No module named 'aiohttp'
```

Added aiohttp to requirements.txt and it runs now